### PR TITLE
Fix database open failing consistently when reloading the app through the dev menu on Android.

### DIFF
--- a/android/src/main/java/com/reactnativeleveldown/LeveldownModule.java
+++ b/android/src/main/java/com/reactnativeleveldown/LeveldownModule.java
@@ -274,6 +274,19 @@ public class LeveldownModule extends ReactContextBaseJavaModule implements Lifec
 
     @Override
     public void onHostDestroy() {
+        this.closeAll();
+    }
+
+    // This method is called when the "Reload" button is pressed in the dev menu.
+    // We need to close all database handles and iterators, otherwise it is not
+    // possible to open another database, as the database lock will still be
+    // held by the process.
+    @Override
+    public void onCatalystInstanceDestroy() {
+        this.closeAll();
+    }
+
+    private void closeAll() {
         for (LevelDB db : dbHandleTable.values()) {
             db.close();
         }


### PR DESCRIPTION
Hi there, thanks so much for this module! We're finding this super useful so far, really great to have a working leveldown implementation for React Native.

I discovered a slight rough edge in the Android bindings: it's not possible to `open` a database once the app has been reloaded using the dev menu.

### To reproduce

1. `open` a database.
2. Reload the app using the dev menu.
3. `open` the database again (in our case, this is happening automatically on app startup.)

### Expected

The database opens as usual.

### Actual

The following error is thrown:

```
Possible Unhandled Promise Rejection (id: 0):
[OpenError: Error opening database cache: com.github.hf.leveldb.exception.LevelDBIOException: IO error: lock /data/user/0/chat.picnic.app.dev/files/cache.db/LOCK: already held by process]
```

Strangely, it's not possible to catch this error by wrapping `open` in try/catch. I still need to investigate why that is the case, but I thought it'd be better to fix this first.

### Solution

`onHostDestroy` is a lifecycle event for the `ReactRootView` activity. We currently close all resources in this method. However, this does not get called when the dev menu reload happens, as the actual root view activity does not get destroyed. Instead, we use the `onCatalystInstanceDestroy()` method to trigger this close.

In classic React Native style, this isn't documented anywhere, and it took me ages to find out how to intercept this reload event. See https://github.com/facebook/react-native/issues/9773 for similar frustrations. Linked from this I found https://github.com/invertase/react-native-firebase/pull/1535, which implements the same solution.

Hope this makes sense, let me know if there's anything you need me to do to get this released :)